### PR TITLE
ci: changed to $GITHUB_OUTPUT from set-output

### DIFF
--- a/.github/workflows/submodule-update.yml
+++ b/.github/workflows/submodule-update.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "::set-output name=datetime::$(date +'%Y%m%d-%H%M%S')"
+        run: echo "datetime=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
 
       - name: Create new branch
         run: hub checkout -b update-submodule-${{ steps.date.outputs.datetime }}


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/